### PR TITLE
Fixed tests by converting to use guard-compat

### DIFF
--- a/guard-scss-lint.gemspec
+++ b/guard-scss-lint.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_path  = 'lib'
 
   spec.add_dependency 'guard', '~> 2.0'
+  spec.add_dependency 'guard-compat', '~>1.0'
   spec.add_dependency 'scss-lint', '~> 0.30.0'
 
   spec.add_development_dependency 'bundler', '~> 1.5'

--- a/lib/guard/scss-lint.rb
+++ b/lib/guard/scss-lint.rb
@@ -1,5 +1,4 @@
-require 'guard'
-require 'guard/plugin'
+require 'guard/compat/plugin'
 require 'scss_lint'
 require 'rainbow'
 require 'rainbow/ext/string'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'guard/compat/test/helper'
 require 'guard/scss-lint'
 
 if ENV['CI']


### PR DESCRIPTION
This plugin is very useful.  Thank you for building it.  The specs were failing and I found that at some point in guard 2 they suggested using guard-compat instead of guard:plugin directly.  This request adds in guard-compat and makes the tests pass again.
