### PR TITLE
Remove scss-lint version restriction

### DIFF
--- a/guard-scss-lint.gemspec
+++ b/guard-scss-lint.gemspec
@@ -6,11 +6,11 @@ require 'guard/scss-lint/version'
 Gem::Specification.new do |spec|
   spec.name          = 'guard-scss-lint'
   spec.version       = Guard::ScssLintVersion::VERSION
-  spec.authors       = ['Chris LoPresto']
-  spec.email         = ['chrislopresto@gmail.com']
+  spec.authors       = ['Chris LoPresto', 'Ian Kynnersley']
+  spec.email         = ['chrislopresto@gmail.com', 'ian@iankynnersley.co.uk']
   spec.summary       = %q{Guard plugin for scss-lint}
   spec.description   = %q{A Guard plugin to lint your .scss files using scss-lint}
-  spec.homepage      = 'https://github.com/chrislopresto/guard-scss-lint'
+  spec.homepage      = 'https://github.com/kpopper/guard-scss-lint'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_path  = 'lib'
 
   spec.add_dependency 'guard', '~> 2.0'
-  spec.add_dependency 'scss-lint', '~> 0.30.0'
+  spec.add_dependency 'scss-lint'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'coveralls'

--- a/lib/guard/scss-lint/version.rb
+++ b/lib/guard/scss-lint/version.rb
@@ -1,5 +1,5 @@
 module Guard
   class ScssLintVersion
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end


### PR DESCRIPTION
We wanted to use this gem with version 0.34.0 of the scss-lint gem so removed the version restriction.

Feel free to ignore any of the author and version changes but it would be great if you could remove the version restriction so that the released version of the gem supports the latest versions.
